### PR TITLE
Add JAVA_HOME to github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
               with:
                   args: build -c ./twilio
               env:
+                  JAVA_HOME: /usr/lib/jvm/default-jvm
                   ACCOUNT_SID: ${{ secrets.ACCOUNT_SID }}
                   AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
                   SAMPLE_FROM_MOBILE: ${{ secrets.SAMPLE_FROM_MOBILE }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,8 +25,9 @@ jobs:
             - name: Ballerina Build
               uses: ballerina-platform/ballerina-action/@master
               with:
-                  args: build -c --skip-tests ./twilio
+                  args: build -c ./twilio
               env:
+                  JAVA_HOME: /usr/lib/jvm/default-jvm
                   ACCOUNT_SID: ${{ secrets.ACCOUNT_SID }}
                   AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
                   SAMPLE_FROM_MOBILE: ${{ secrets.SAMPLE_FROM_MOBILE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,9 @@ jobs:
             - name: Ballerina Build
               uses: ballerina-platform/ballerina-action/@master
               with:
-                  args: build -c --skip-tests ./twilio
+                  args: build -c ./twilio
               env:
+                  JAVA_HOME: /usr/lib/jvm/default-jvm
                   ACCOUNT_SID: ${{ secrets.ACCOUNT_SID }}
                   AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
                   SAMPLE_FROM_MOBILE: ${{ secrets.SAMPLE_FROM_MOBILE }}


### PR DESCRIPTION
## Purpose
> Github workflow failed because the JAVA_HOME environment variable was not explicitly defined. This PR add this JAVA_HOME environment variable.

## Release note
> 0.99.7

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
## Related PRs
> #80 