### PR TITLE
Bump versions for slbeta3 in master branch

### DIFF
--- a/twilio/Dependencies.toml
+++ b/twilio/Dependencies.toml
@@ -1,39 +1,39 @@
 [[dependency]]
 org = "ballerina"
 name = "url"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "crypto"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "log"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "auth"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "io"
-version = "0.6.0-beta.2"
+version = "0.6.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "mime"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "os"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"

--- a/twilio/Package.md
+++ b/twilio/Package.md
@@ -8,7 +8,7 @@ sending an SMS, getting message details, making a voice call etc.
 ### Compatibility
 |                               | Version                              |
 |-------------------------------|--------------------------------------|
-| Ballerina Language            | Swan Lake Beta 2                     |
+| Ballerina Language            | Swan Lake Beta 3                     |
 | Twilio Basic API              | 2010-04-01                           |     
 
 ## Report issues


### PR DESCRIPTION
## Purpose
- Bump version to slbeta3 in Dependencies.toml, README.md and Package.md

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta3-SNAPSHOT
