### PR TITLE
Remove irrelevant doc comment

### DIFF
--- a/twilio/endpoint.bal
+++ b/twilio/endpoint.bal
@@ -177,7 +177,6 @@ public isolated client class Client {
 #
 # + accountSId - Unique identifier of the account
 # + authToken - The authentication token of the account
-# + secureSocket - SSL configurations 
 @display{label: "Connection Config"} 
 public type ConnectionConfig record {
     @display{label: "Account SID"} 


### PR DESCRIPTION
## Purpose
Remove irrelevant doc comment for `secureSocket` which is not available in the record

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta3
