### PR TITLE
Add API key credential support

### DIFF
--- a/twilio/Module.md
+++ b/twilio/Module.md
@@ -43,8 +43,10 @@ configurable string accountSId = ?;
 configurable string authToken = ?;
 
 twilio:ConnectionConfig twilioConfig = {
-    accountSId: accountSId,
-    authToken: authToken
+    auth: {
+        accountSId: accountSId,
+        authToken: authToken
+    }
 };
 
 twilio:Client twilioClient = new (twilioConfig);

--- a/twilio/samples/client samples/getAccountDetail.bal
+++ b/twilio/samples/client samples/getAccountDetail.bal
@@ -23,8 +23,10 @@ configurable string authToken = ?;
 public function main() {
     //Twilio Client configuration
     twilio:ConnectionConfig twilioConfig = {
-        accountSId: accountSId,
-        authToken: authToken
+        auth: {
+            accountSId: accountSId,
+            authToken: authToken
+        }
     };
 
     //Twilio Client

--- a/twilio/samples/client samples/getMessage.bal
+++ b/twilio/samples/client samples/getMessage.bal
@@ -23,8 +23,10 @@ configurable string authToken = ?;
 public function main() {
     //Twilio Client configuration
     twilio:ConnectionConfig twilioConfig = {
-        accountSId: accountSId,
-        authToken: authToken
+        auth: {
+            accountSId: accountSId,
+            authToken: authToken
+        }
     };
 
     //Twilio Client

--- a/twilio/samples/client samples/makeVoiceCall.bal
+++ b/twilio/samples/client samples/makeVoiceCall.bal
@@ -32,8 +32,10 @@ public function main() returns error?{
       
    //Twilio Client configuration
     twilio:ConnectionConfig twilioConfig = {
-        accountSId: accountSId,
-        authToken: authToken
+        auth: {
+            accountSId: accountSId,
+            authToken: authToken
+        }
     };
 
     //Twilio Client

--- a/twilio/samples/client samples/sendSMS.bal
+++ b/twilio/samples/client samples/sendSMS.bal
@@ -27,8 +27,10 @@ configurable string message = "Wso2-Test-SMS-Message";
 public function main() {
     //Twilio Client configuration
     twilio:ConnectionConfig twilioConfig = {
-        accountSId: accountSId,
-        authToken: authToken
+        auth: {
+            accountSId: accountSId,
+            authToken: authToken
+        }
     };
 
     //Twilio Client

--- a/twilio/samples/client samples/sendWhatsappMessage.bal
+++ b/twilio/samples/client samples/sendWhatsappMessage.bal
@@ -25,8 +25,10 @@ configurable string toMobile = ?;
 public function main() {
     //Twilio Client configuration
     twilio:ConnectionConfig twilioConfig = {
-        accountSId: accountSId,
-        authToken: authToken
+        auth: {
+            accountSId: accountSId,
+            authToken: authToken
+        }
     };
 
     //Twilio Client

--- a/twilio/samples/listener samples/deliveredSMSEvent.bal
+++ b/twilio/samples/listener samples/deliveredSMSEvent.bal
@@ -18,8 +18,8 @@ import ballerina/log;
 import ballerinax/twilio;
 import ballerinax/twilio.'listener as twilioListener;
 
-configurable string & readonly twilioAccountSid = ?;
-configurable string & readonly twilioAuthToken = ?;
+configurable string & readonly accountSid = ?;
+configurable string & readonly authToken = ?;
 configurable string & readonly fromNumber = ?;
 configurable string & readonly toNumber = ?;
 configurable string & readonly test_message = ?;
@@ -37,8 +37,10 @@ service / on tListener {
 
 public function main() {
     twilio:ConnectionConfig twilioConfig = {
-        accountSId: twilioAccountSid,
-        authToken: twilioAuthToken
+        auth: {
+            accountSId: accountSid,
+            authToken: authToken
+        }
     };
     twilio:Client twilioClient = new (twilioConfig);
     var details = twilioClient->sendSms(fromNumber, toNumber, test_message, callbackUrl);

--- a/twilio/samples/listener samples/queuedSMSEvent.bal
+++ b/twilio/samples/listener samples/queuedSMSEvent.bal
@@ -18,8 +18,8 @@ import ballerina/log;
 import ballerinax/twilio;
 import ballerinax/twilio.'listener as twilioListener;
 
-configurable string & readonly twilioAccountSid = ?;
-configurable string & readonly twilioAuthToken = ?;
+configurable string & readonly accountSid = ?;
+configurable string & readonly authToken = ?;
 configurable string & readonly fromNumber = ?;
 configurable string & readonly toNumber = ?;
 configurable string & readonly test_message = ?;
@@ -37,8 +37,10 @@ service / on tListener {
 
 public function main() {
     twilio:ConnectionConfig twilioConfig = {
-        accountSId: twilioAccountSid,
-        authToken: twilioAuthToken
+        auth: {
+            accountSId: accountSid,
+            authToken: authToken
+        }
     };
     twilio:Client twilioClient = new (twilioConfig);
     var details = twilioClient->sendSms(fromNumber, toNumber, test_message, callbackUrl);

--- a/twilio/samples/listener samples/sentSMSEvent.bal
+++ b/twilio/samples/listener samples/sentSMSEvent.bal
@@ -18,8 +18,8 @@ import ballerina/log;
 import ballerinax/twilio;
 import ballerinax/twilio.'listener as twilioListener;
 
-configurable string & readonly twilioAccountSid = ?;
-configurable string & readonly twilioAuthToken = ?;
+configurable string & readonly accountSid = ?;
+configurable string & readonly authToken = ?;
 configurable string & readonly fromNumber = ?;
 configurable string & readonly toNumber = ?;
 configurable string & readonly test_message = ?;
@@ -37,8 +37,10 @@ service / on tListener {
 
 public function main() {
     twilio:ConnectionConfig twilioConfig = {
-        accountSId: twilioAccountSid,
-        authToken: twilioAuthToken
+        auth: {
+            accountSId: accountSid,
+            authToken: authToken
+        }
     };
     twilio:Client twilioClient = new (twilioConfig);
     var details = twilioClient->sendSms(fromNumber, toNumber, test_message, callbackUrl);

--- a/twilio/tests/test.bal
+++ b/twilio/tests/test.bal
@@ -19,10 +19,10 @@ import ballerina/test;
 import ballerina/os;
 
 // This user-id is initialized after the testAuthyUserAdd() function call and will be used for testAuthyUserDelete()
-string testUserId = "";
+string testUserId = EMPTY_STRING;
 
 // This is message SID that provided by twilio.
-string messageSid = "";
+string messageSid = EMPTY_STRING;
 
 // ACCOUNT_SID, AUTH_TOKEN, AUTHY_API_KEY should be changed with your own account credentials
 configurable string twilioAccountSid = os:getEnv("ACCOUNT_SID");
@@ -32,11 +32,24 @@ configurable string toNumber = os:getEnv("SAMPLE_TO_MOBILE");
 configurable string test_message = os:getEnv("SAMPLE_MESSAGE");
 configurable string fromWhatsappNumber = os:getEnv("SAMPLE_WHATSAPP_SANDBOX");
 configurable string twimlUrl = os:getEnv("SAMPLE_TWIML_URL");
+configurable string twilioAPIKey = os:getEnv("twilioAPIKey");
+configurable string twilioAPISecret = os:getEnv("twilioAPISecret");
 
 ConnectionConfig twilioConfig = {
-    accountSId: twilioAccountSid,
-    authToken: twilioAuthToken
+    auth: {
+        accountSId: twilioAccountSid,
+        authToken: twilioAuthToken
+    }
 };
+
+// ConnectionConfig twilioConfig = {
+//     auth: {
+//         accountSId: twilioAccountSid,
+//         apiKey: twilioAPIKey,
+//         apiSecret: twilioAPISecret
+//     }
+// };
+
 Client twilioClient = check new (twilioConfig);
 
 @test:Config {
@@ -44,10 +57,6 @@ Client twilioClient = check new (twilioConfig);
     enable: true
 }
 function testAccountDetails() {
-    ConnectionConfig twilioConfig = {
-        accountSId: twilioAccountSid,
-        authToken: twilioAuthToken
-    };
     log:printInfo("\n ---------------------------------------------------------------------------");
     log:printInfo("twilioClient -> getAccountDetails()");
     var details = twilioClient->getAccountDetails();


### PR DESCRIPTION
## Purpose
> Adding Twilio API key authentication for Twilio connector. **This will be a breaking change for the current Twilio connector based implementations.**
Fixes: https://github.com/ballerina-platform/ballerina-extended-library/issues/66

Before: 
1. **Auth Token-Based Authentication method**
```
twilio:ConnectionConfig twilioConfig = {
        accountSId: accountSId,
        authToken: authToken
   };
```
New Improvement: 
1. **Auth token-based Authentication method**
```
    twilio:ConnectionConfig config = {
        auth: {
            accountSId: accountSId,
            authToken: authToken
        }
    };
```
2. API key based authentication method
```
twilio:ConnectionConfig config = {
    auth: {
            accountSId: accountSid,
            apiKey: twilioAPIKey,
            apiSecret: twilioAPISecret
    }
};
```
## Goals
> Providing multiple authentication methods

## Approach
1. Created separate records for each method
2. Added another record with a union type of both records
3. Fixed the init method
4. Updated samples

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Ballerina Swan Lake Beta3

## Samples
Please refer to the sample directory of the repo. for examples
 
## Learning
> https://www.twilio.com/blog/better-twilio-authentication-csharp-twilio-api-keys