### PR TITLE
Bump jar version to 0.99.11 same as bal package

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=org.ballerinalang.twilio
-version=0.99.10
+version=0.99.11
 ballerinaLangVersion=2.0.0-beta.3
 
 ballerinaTomlParserVersion=1.2.2

--- a/twilio/Ballerina.toml
+++ b/twilio/Ballerina.toml
@@ -9,8 +9,7 @@ keywords = ["twilio", "sms", "call", "otp", "whatsapp", "webhook"]
 license = ["Apache-2.0"]
 
 [[platform.java11.dependency]]
-path = "../java-wrapper/build/libs/java-wrapper-0.99.10.jar"
+path = "../java-wrapper/build/libs/java-wrapper-0.99.11.jar"
 groupId = "org.ballerinalang.twilio"
 artifactId = "java-wrapper"
-version = "0.99.10"
-
+version = "0.99.11"


### PR DESCRIPTION
# Description
Bump java component version to 0.99.11 same as ballerina package version mentioned in Ballerina.toml
 
### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?