### PR TITLE
Add *Http:Service from Beta4 changes

### DIFF
--- a/twilio/Dependencies.toml
+++ b/twilio/Dependencies.toml
@@ -173,9 +173,7 @@ org = "ballerina"
 name = "lang.runtime"
 version = "0.0.0"
 dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.array"},
-	{org = "ballerina", name = "lang.value"}
+	{org = "ballerina", name = "jballerina.java"}
 ]
 
 [[package]]

--- a/twilio/modules/listener/http_service.bal
+++ b/twilio/modules/listener/http_service.bal
@@ -20,16 +20,14 @@ import ballerina/log;
 import ballerina/url;
 
 isolated service class HttpService {
-
+    *http:Service;
     private final boolean isOnSmsQueued;
     private final boolean isOnSmsSent;
     private final boolean isOnSmsDelivered;
     private final boolean isOnSmsReceived;
-
     private final boolean isOnCallRang;
     private final boolean isOnCallAnswered;
     private final boolean isOnCallCompleted;
-    
     private final HttpToTwilioAdaptor adaptor;
     private final string authToken;
     private final string callbackUrl;
@@ -61,8 +59,6 @@ isolated service class HttpService {
     # + return - If success, returns TwilioEvent object, else returns error
     isolated resource function post onChange(http:Caller caller, http:Request twilioRequest) returns 
                                            error? {
-        SmsStatusChangeEvent smsEvent = {};
-        CallStatusChangeEvent callEvent = {};
         map<string> payload = check twilioRequest.getFormParams();
         check caller->respond(http:STATUS_OK); 
         if(payload.hasKey("CallStatus")) {

--- a/twilio/modules/listener/simple_http_service.bal
+++ b/twilio/modules/listener/simple_http_service.bal
@@ -14,4 +14,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-public type SimpleHttpService service object {};
+public type SimpleHttpService distinct service object {};


### PR DESCRIPTION
# Description
- Fix https://github.com/ballerina-platform/ballerina-extended-library/issues/166

All the standard library service definitions are now made `distinct`. Therefore, if you have created services without using the service declaration, you need to do the type inclusion explicitly as follows.

```
public service class MyHttpService {
    *http:Service;
   // some resources
}

public function main() returns error? {
    Listener l = check new;
    MyService myService = new;
    check l.attach(myService, "/foo");  
}

Or

http:Service myService = service object {
   // some resources
}
```



One line release note: 
- Make SimpleHttpService service type distinct 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Build & run the test cases using the following pack
https://github.com/ballerina-platform/ballerina-distribution/actions/runs/1478991785

**Test Configuration**:
* Ballerina Version: SLBeta4
* Operating System: Ubuntu 20.04
* Java SDK: 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
