### PR TITLE
Update categories in Twilio

### DIFF
--- a/twilio/Ballerina.toml
+++ b/twilio/Ballerina.toml
@@ -6,7 +6,7 @@ version = "2.2.0"
 export = ["twilio", "twilio.listener"]
 authors = ["Ballerina"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-twilio"
-keywords = ["Communication/Phone & SMS", "Cost/Paid"]
+keywords = ["Communication/Call & SMS", "Cost/Paid"]
 icon = "icon.png"
 license = ["Apache-2.0"]
 


### PR DESCRIPTION
Related https://github.com/wso2-enterprise/choreo/issues/12741

>There are 12 connectors for Call & SMS and only Twilio for Phone & SMS, hence can we change that connector also to have Call & SMS