### PR TITLE
Update GraalVM workflow with new command option

### DIFF
--- a/.github/workflows/build-with-bal-test-native.yml
+++ b/.github/workflows/build-with-bal-test-native.yml
@@ -31,4 +31,4 @@ jobs:
           version: latest
 
       - name: Run Ballerina build using the native executable
-        run: bal build --native ./twilio
+        run: bal build --graalvm ./twilio


### PR DESCRIPTION
This PR will rename the command option in the graalVM workflow from --native to --graalvm. Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/531