### PR TITLE
Fix error `You have unversioned files:` in release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.zip
 *.tar.gz
 *.rar
+*.deb
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*


### PR DESCRIPTION
## Purpose
When running the Release Workflow or attempting to publish a package, an error occurs with the message `You have unversioned files:`.This issue can be mitigated by either adding the relevant build/files to the .gitignore

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/5931

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility