### PR TITLE
Change org name to wso2 in examples

### DIFF
--- a/examples/accounts/create-sub-account/Ballerina.toml
+++ b/examples/accounts/create-sub-account/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "create_sub_account"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/accounts/create-sub-account/Ballerina.toml
+++ b/examples/accounts/create-sub-account/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "create_sub_account"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/accounts/fetch-account/Ballerina.toml
+++ b/examples/accounts/fetch-account/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "fetch_account"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/accounts/fetch-account/Ballerina.toml
+++ b/examples/accounts/fetch-account/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "fetch_account"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/accounts/fetch-balance/Ballerina.toml
+++ b/examples/accounts/fetch-balance/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "fetch_balance"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/accounts/fetch-balance/Ballerina.toml
+++ b/examples/accounts/fetch-balance/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "fetch_balance"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/accounts/list-accounts/Ballerina.toml
+++ b/examples/accounts/list-accounts/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "list_accounts"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/accounts/list-accounts/Ballerina.toml
+++ b/examples/accounts/list-accounts/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "list_accounts"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/accounts/update-account/Ballerina.toml
+++ b/examples/accounts/update-account/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "update_account"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/accounts/update-account/Ballerina.toml
+++ b/examples/accounts/update-account/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "update_account"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/calls/create-call/Ballerina.toml
+++ b/examples/calls/create-call/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "create_call"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/calls/create-call/Ballerina.toml
+++ b/examples/calls/create-call/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "create_call"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/calls/delete-call-log/Ballerina.toml
+++ b/examples/calls/delete-call-log/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "delete_call_log"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/calls/delete-call-log/Ballerina.toml
+++ b/examples/calls/delete-call-log/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "delete_call_log"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/calls/fetch-call-log/Ballerina.toml
+++ b/examples/calls/fetch-call-log/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "fetch_call_log"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/calls/fetch-call-log/Ballerina.toml
+++ b/examples/calls/fetch-call-log/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "fetch_call_log"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/calls/list-call-logs/Ballerina.toml
+++ b/examples/calls/list-call-logs/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "list_call_logs"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/calls/list-call-logs/Ballerina.toml
+++ b/examples/calls/list-call-logs/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "list_call_logs"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/messages/create-sms-message/Ballerina.toml
+++ b/examples/messages/create-sms-message/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "create_sms_message"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/messages/create-sms-message/Ballerina.toml
+++ b/examples/messages/create-sms-message/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "create_sms_message"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/messages/create-whatsapp-message/Ballerina.toml
+++ b/examples/messages/create-whatsapp-message/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "create_whatsapp_message"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/messages/create-whatsapp-message/Ballerina.toml
+++ b/examples/messages/create-whatsapp-message/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "create_whatsapp_message"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/messages/delete-message-log/Ballerina.toml
+++ b/examples/messages/delete-message-log/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "delete_message"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/messages/delete-message-log/Ballerina.toml
+++ b/examples/messages/delete-message-log/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "delete_message"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/messages/fetch-message-log/Ballerina.toml
+++ b/examples/messages/fetch-message-log/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "fetch_message"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/messages/fetch-message-log/Ballerina.toml
+++ b/examples/messages/fetch-message-log/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "fetch_message"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/messages/list-message-logs/Ballerina.toml
+++ b/examples/messages/list-message-logs/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "dilanperera"
+org = "wso2"
 name = "list_messages"
 version = "0.1.0"
 distribution = "2201.8.2"

--- a/examples/messages/list-message-logs/Ballerina.toml
+++ b/examples/messages/list-message-logs/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-org = "wso2"
+org = "twilio_samples"
 name = "list_messages"
 version = "0.1.0"
 distribution = "2201.8.2"


### PR DESCRIPTION
## Purpose
Change org name to `wso2` in example projects.

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility